### PR TITLE
Router Additions

### DIFF
--- a/examples/basic/main.zig
+++ b/examples/basic/main.zig
@@ -35,7 +35,7 @@ pub fn main() !void {
     const num: i8 = 12;
 
     try router.serve_route("/", Route.init().get(&num, struct {
-        pub fn handler_fn(ctx: *Context, id: *const i8) !void {
+        fn handler_fn(ctx: *Context, id: *const i8) !void {
             const body_fmt =
                 \\ <!DOCTYPE html>
                 \\ <html>
@@ -55,6 +55,16 @@ pub fn main() !void {
                 .status = .OK,
                 .mime = http.Mime.HTML,
                 .body = body[0..],
+            });
+        }
+    }.handler_fn));
+
+    router.serve_not_found(Route.init().get({}, struct {
+        fn handler_fn(ctx: *Context, _: void) !void {
+            try ctx.respond(.{
+                .status = .@"Not Found",
+                .mime = http.Mime.HTML,
+                .body = "Not Found Handler!",
             });
         }
     }.handler_fn));

--- a/examples/fs/main.zig
+++ b/examples/fs/main.zig
@@ -63,7 +63,9 @@ pub fn main() !void {
         &router,
         struct {
             fn entry(rt: *Runtime, r: *const Router) !void {
-                var server = Server.init(.{ .allocator = rt.allocator });
+                var server = Server.init(.{
+                    .allocator = rt.allocator,
+                });
                 try server.bind(host, port);
                 try server.serve(r, rt);
             }

--- a/src/core/job.zig
+++ b/src/core/job.zig
@@ -5,7 +5,7 @@ const TaskFn = @import("tardy").TaskFn;
 
 pub const AfterType = union(enum) {
     recv,
-    sse: struct {
+    other: struct {
         func: *const anyopaque,
         ctx: *anyopaque,
     },

--- a/src/http/response.zig
+++ b/src/http/response.zig
@@ -50,7 +50,7 @@ pub const Response = struct {
         }
     }
 
-    pub fn headers_into_buffer(self: *Response, buffer: []u8, content_length: ?u32) ![]u8 {
+    pub fn headers_into_buffer(self: *Response, buffer: []u8, content_length: ?usize) ![]u8 {
         var index: usize = 0;
 
         // Status Line

--- a/src/http/route.zig
+++ b/src/http/route.zig
@@ -80,7 +80,7 @@ pub fn Route(comptime Server: type) type {
             // You can either give a void (if you don't want to pass data through) or a pointer.
             comptime assert(@typeInfo(@TypeOf(data)) == .Pointer or @typeInfo(@TypeOf(data)) == .Void);
             const inner_data = switch (comptime @typeInfo(@TypeOf(data))) {
-                .Void => undefined,
+                .Void => 1, // Needs to not be 0.
                 .Pointer => @intFromPtr(data),
                 else => unreachable,
             };

--- a/src/http/route.zig
+++ b/src/http/route.zig
@@ -80,7 +80,7 @@ pub fn Route(comptime Server: type) type {
             // You can either give a void (if you don't want to pass data through) or a pointer.
             comptime assert(@typeInfo(@TypeOf(data)) == .Pointer or @typeInfo(@TypeOf(data)) == .Void);
             const inner_data = switch (comptime @typeInfo(@TypeOf(data))) {
-                .Void => @intFromPtr(&data),
+                .Void => undefined,
                 .Pointer => @intFromPtr(data),
                 else => unreachable,
             };

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -88,7 +88,7 @@ pub fn Router(comptime Server: type) type {
 
             // Set file size.
             provision.file_size = stat.size;
-            log.err("file size: {d}", .{provision.file_size});
+            log.debug("file size: {d}", .{provision.file_size});
 
             // generate the etag and attach it to the response.
             var hash = std.hash.Wyhash.init(0);
@@ -134,7 +134,7 @@ pub fn Router(comptime Server: type) type {
 
             if (!success) {
                 log.warn("starting file stream failed!", .{});
-                try provision.context.close();
+                std.posix.close(provision.fd);
                 return;
             }
 
@@ -188,7 +188,6 @@ pub fn Router(comptime Server: type) type {
             if (!success) {
                 log.warn("send file stream failed!", .{});
                 std.posix.close(provision.fd);
-                try provision.context.close();
                 return;
             }
 

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -276,6 +276,7 @@ pub fn Router(comptime Server: type) type {
         }
 
         pub fn serve_not_found(self: *Self, route: Route) void {
+            assert(!self.locked);
             self.not_found_route = route;
         }
 
@@ -299,7 +300,7 @@ pub fn Router(comptime Server: type) type {
                 queries.clearRetainingCapacity();
                 if (self.not_found_route) |not_found| {
                     return FoundRoute{ .route = not_found, .captures = captures[0..0], .queries = queries };
-                } else return FoundRoute{ .route = base_404_route, .captures = captures[0..], .queries = queries };
+                } else return FoundRoute{ .route = base_404_route, .captures = captures[0..0], .queries = queries };
             };
         }
     };

--- a/src/http/server.zig
+++ b/src/http/server.zig
@@ -670,10 +670,8 @@ pub fn Server(comptime security: Security) type {
                     TLSType,
                     self.config.size_connections_max,
                 );
-                if (comptime security == .tls) {
-                    for (tls_slice) |*tls| {
-                        tls.* = null;
-                    }
+                for (tls_slice) |*tls| {
+                    tls.* = null;
                 }
 
                 // since slices are fat pointers...

--- a/src/http/sse.zig
+++ b/src/http/sse.zig
@@ -55,24 +55,7 @@ pub fn SSE(comptime Server: type) type {
             buffer[index] = '\n';
             index += 1;
 
-            const pslice = Pseudoslice.init(buffer[0..index], "", buffer);
-
-            const first_chunk = Server.prepare_send(
-                self.context.runtime,
-                self.context.provision,
-                .{ .sse = .{
-                    .func = then,
-                    .ctx = then_context,
-                } },
-                pslice,
-            ) catch unreachable;
-
-            self.context.runtime.net.send(
-                self.context.provision,
-                Server.send_then_sse_task,
-                self.context.provision.socket,
-                first_chunk,
-            ) catch unreachable;
+            try self.context.send_then(buffer[0..index], then_context, then);
         }
     };
 }


### PR DESCRIPTION
This PR iterates on the current Router by bringing in both QOL features and necessary security hardening.

- Router now provides a `serve_not_found` route where you can provide a handler for deciding what happens when a Not Found route is triggered. The basic example is updated to highlight use of it.
- Router now ensures that any queries to the `serve_fs_dir` path rely within the path, preventing path traversal attacks that may have been possible before.
- Router now will attach an ETag to any files served through `serve_fs_dir`, allowing for rudimentary caching using the size and last modified time. It will automatically return `304` if the browser/client requests a matching file.
- Serving from the filesystem no longer requires the entire file to be copied into memory, reducing both the memory footprint of `serve_fs_dir` and also allowing for files that are larger than RAM to be served (eg. 100 GB file on 16 GB of RAM). This is thanks to Tardy.
- Fixes a bug within the SSE implementation that may have led to connections entering a `recv` state if the data that was being sent to the client got fragmented by the kernel.