### PR TITLE
Support for URL Encoded Forms

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -30,6 +30,7 @@ pub fn build(b: *std.Build) void {
 
     add_example(b, "basic", false, target, optimize, zzz);
     add_example(b, "cookies", false, target, optimize, zzz);
+    add_example(b, "form", false, target, optimize, zzz);
     add_example(b, "fs", false, target, optimize, zzz);
     add_example(b, "middleware", false, target, optimize, zzz);
     add_example(b, "sse", false, target, optimize, zzz);

--- a/examples/form/main.zig
+++ b/examples/form/main.zig
@@ -92,7 +92,6 @@ pub fn main() !void {
     }, .{});
     defer router.deinit(allocator);
 
-    // create socket for tardy
     var socket = try Socket.init(.{ .tcp = .{ .host = host, .port = port } });
     defer socket.close_blocking();
     try socket.bind();
@@ -110,8 +109,6 @@ pub fn main() !void {
                 var server = Server.init(rt.allocator, .{
                     .stack_size = 1024 * 1024 * 4,
                     .socket_buffer_bytes = 1024 * 2,
-                    .keepalive_count_max = null,
-                    .connection_count_max = 1024,
                 });
                 try server.serve(rt, p.router, p.socket);
             }

--- a/examples/form/main.zig
+++ b/examples/form/main.zig
@@ -68,6 +68,7 @@ fn generate_handler(ctx: *const Context, _: void) !Respond {
             info.weight orelse "none",
         },
     );
+
     return Respond{ .standard = .{
         .status = .OK,
         .mime = http.Mime.TEXT,

--- a/src/http/form.zig
+++ b/src/http/form.zig
@@ -1,0 +1,85 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+const AnyCaseStringMap = @import("../core/any_case_string_map.zig").AnyCaseStringMap;
+const Context = @import("context.zig").Context;
+
+pub fn decode_alloc(allocator: std.mem.Allocator, input: []const u8) ![]const u8 {
+    var list = try std.ArrayListUnmanaged(u8).initCapacity(allocator, input.len);
+    defer list.deinit(allocator);
+
+    var input_index: usize = 0;
+    while (input_index < input.len) {
+        defer input_index += 1;
+        const byte = input[input_index];
+        switch (byte) {
+            '%' => {
+                if (input_index + 2 >= input.len) return error.InvalidEncoding;
+                list.appendAssumeCapacity(
+                    try std.fmt.parseInt(u8, input[input_index + 1 .. input_index + 3], 16),
+                );
+                input_index += 2;
+            },
+            '+' => list.appendAssumeCapacity(' '),
+            else => list.appendAssumeCapacity(byte),
+        }
+    }
+
+    return list.toOwnedSlice(allocator);
+}
+
+pub fn Form(comptime T: type) type {
+    return struct {
+        pub fn parse(ctx: *const Context) !T {
+            var m = AnyCaseStringMap.init(ctx.allocator);
+            defer m.deinit();
+
+            std.log.debug("body: {?s}", .{ctx.request.body});
+
+            var map: *const AnyCaseStringMap = if (ctx.request.body) |body| blk: {
+                var pairs = std.mem.splitScalar(u8, body, '&');
+                while (pairs.next()) |pair| {
+                    var kv = std.mem.splitScalar(u8, pair, '=');
+
+                    const key = kv.next() orelse return error.MalformedForm;
+                    const decoded_key = try decode_alloc(ctx.allocator, key);
+
+                    const value = kv.next() orelse return error.MalformedForm;
+                    const decoded_value = try decode_alloc(ctx.allocator, value);
+
+                    assert(kv.next() == null);
+                    try m.putNoClobber(decoded_key, decoded_value);
+                }
+
+                break :blk &m;
+            } else ctx.queries;
+
+            var ret: T = undefined;
+            assert(@typeInfo(T) == .Struct);
+            const struct_info = @typeInfo(T).Struct;
+            inline for (struct_info.fields) |field| {
+                const maybe_value_str: ?[]const u8 = map.get(field.name);
+
+                if (maybe_value_str) |value| {
+                    switch (field.type) {
+                        []const u8 => @field(ret, field.name) = value,
+                        bool => @field(ret, field.name) = std.mem.eql(u8, value, "true"),
+                        else => switch (@typeInfo(field.type)) {
+                            .Int => |int_info| {
+                                @field(ret, field.name) = switch (int_info.signedness) {
+                                    .unsigned => try std.fmt.parseUnsigned(field.type, value, 10),
+                                    .signed => try std.fmt.parseInt(field.type, value, 10),
+                                };
+                            },
+                            else => unreachable,
+                        },
+                    }
+                } else if (field.default_value) |default| {
+                    @field(ret, field.name) = @as(*const field.type, @ptrCast(@alignCast(default))).*;
+                } else return error.FieldEmpty;
+            }
+
+            return ret;
+        }
+    };
+}

--- a/src/http/form.zig
+++ b/src/http/form.zig
@@ -104,8 +104,6 @@ pub fn Form(comptime T: type) type {
 pub fn Query(comptime T: type) type {
     return struct {
         pub fn parse(ctx: *const Context) !T {
-            var m = AnyCaseStringMap.init(ctx.allocator);
-            defer m.deinit();
             return parse_struct(T, ctx.queries);
         }
     };

--- a/src/http/form.zig
+++ b/src/http/form.zig
@@ -28,59 +28,85 @@ pub fn decode_alloc(allocator: std.mem.Allocator, input: []const u8) ![]const u8
     return list.toOwnedSlice(allocator);
 }
 
+fn parse_from(comptime name: []const u8, comptime T: type, value: []const u8) !T {
+    switch (@typeInfo(T)) {
+        .Int => |info| {
+            return switch (info.signedness) {
+                .unsigned => try std.fmt.parseUnsigned(T, value, 10),
+                .signed => try std.fmt.parseInt(T, value, 10),
+            };
+        },
+        .Float => |_| {
+            return try std.fmt.parseFloat(T, value);
+        },
+        .Optional => |info| {
+            return @as(T, try parse_from(name, info.child, value));
+        },
+        else => switch (T) {
+            []const u8 => return value,
+            bool => return std.mem.eql(u8, value, "true"),
+            else => std.debug.panic("Unsupported field type \"{s}\"", .{@typeName(T)}),
+        },
+    }
+}
+
+fn parse_struct(comptime T: type, map: *const AnyCaseStringMap) !T {
+    var ret: T = undefined;
+    assert(@typeInfo(T) == .Struct);
+    const struct_info = @typeInfo(T).Struct;
+    inline for (struct_info.fields) |field| {
+        const maybe_value_str: ?[]const u8 = map.get(field.name);
+
+        if (maybe_value_str) |value| {
+            @field(ret, field.name) = try parse_from(field.name, field.type, value);
+        } else if (field.default_value) |default| {
+            @field(ret, field.name) = @as(*const field.type, @ptrCast(@alignCast(default))).*;
+        } else if (@typeInfo(field.type) == .Optional) {
+            @field(ret, field.name) = null;
+        } else return error.FieldEmpty;
+    }
+
+    return ret;
+}
+
+/// Parses Form data from a request body in `x-www-form-urlencoded` format.
 pub fn Form(comptime T: type) type {
     return struct {
         pub fn parse(ctx: *const Context) !T {
             var m = AnyCaseStringMap.init(ctx.allocator);
             defer m.deinit();
 
-            var map: *const AnyCaseStringMap = if (ctx.request.body) |body| blk: {
-                var pairs = std.mem.splitScalar(u8, body, '&');
-                while (pairs.next()) |pair| {
-                    var kv = std.mem.splitScalar(u8, pair, '=');
+            const map: *const AnyCaseStringMap = map: {
+                if (ctx.request.body) |body| {
+                    var pairs = std.mem.splitScalar(u8, body, '&');
+                    while (pairs.next()) |pair| {
+                        var kv = std.mem.splitScalar(u8, pair, '=');
 
-                    const key = kv.next() orelse return error.MalformedForm;
-                    const decoded_key = try decode_alloc(ctx.allocator, key);
+                        const key = kv.next() orelse return error.MalformedForm;
+                        const decoded_key = try decode_alloc(ctx.allocator, key);
 
-                    const value = kv.next() orelse return error.MalformedForm;
-                    const decoded_value = try decode_alloc(ctx.allocator, value);
+                        const value = kv.next() orelse return error.MalformedForm;
+                        const decoded_value = try decode_alloc(ctx.allocator, value);
 
-                    assert(kv.next() == null);
-                    try m.putNoClobber(decoded_key, decoded_value);
-                }
-
-                break :blk &m;
-            } else ctx.queries;
-
-            var ret: T = undefined;
-            assert(@typeInfo(T) == .Struct);
-            const struct_info = @typeInfo(T).Struct;
-            inline for (struct_info.fields) |field| {
-                const maybe_value_str: ?[]const u8 = map.get(field.name);
-
-                if (maybe_value_str) |value| {
-                    switch (field.type) {
-                        []const u8 => @field(ret, field.name) = value,
-                        bool => @field(ret, field.name) = std.mem.eql(u8, value, "true"),
-                        else => switch (@typeInfo(field.type)) {
-                            .Int => |info| {
-                                @field(ret, field.name) = switch (info.signedness) {
-                                    .unsigned => try std.fmt.parseUnsigned(field.type, value, 10),
-                                    .signed => try std.fmt.parseInt(field.type, value, 10),
-                                };
-                            },
-                            .Float => |_| {
-                                @field(ret, field.name) = try std.fmt.parseFloat(field.type, value);
-                            },
-                            else => unreachable,
-                        },
+                        assert(kv.next() == null);
+                        try m.putNoClobber(decoded_key, decoded_value);
                     }
-                } else if (field.default_value) |default| {
-                    @field(ret, field.name) = @as(*const field.type, @ptrCast(@alignCast(default))).*;
-                } else return error.FieldEmpty;
-            }
+                } else return error.BodyEmpty;
+                break :map &m;
+            };
 
-            return ret;
+            return parse_struct(T, map);
+        }
+    };
+}
+
+/// Parses Form data from request URL query parameters.
+pub fn Query(comptime T: type) type {
+    return struct {
+        pub fn parse(ctx: *const Context) !T {
+            var m = AnyCaseStringMap.init(ctx.allocator);
+            defer m.deinit();
+            return parse_struct(T, ctx.queries);
         }
     };
 }

--- a/src/http/lib.zig
+++ b/src/http/lib.zig
@@ -7,6 +7,7 @@ pub const Mime = @import("mime.zig").Mime;
 pub const Encoding = @import("encoding.zig").Encoding;
 pub const Date = @import("date.zig").Date;
 pub const Cookie = @import("cookie.zig").Cookie;
+pub const Form = @import("form.zig").Form;
 
 pub const Context = @import("context.zig").Context;
 

--- a/src/http/lib.zig
+++ b/src/http/lib.zig
@@ -7,7 +7,9 @@ pub const Mime = @import("mime.zig").Mime;
 pub const Encoding = @import("encoding.zig").Encoding;
 pub const Date = @import("date.zig").Date;
 pub const Cookie = @import("cookie.zig").Cookie;
+
 pub const Form = @import("form.zig").Form;
+pub const Query = @import("form.zig").Query;
 
 pub const Context = @import("context.zig").Context;
 

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -65,18 +65,19 @@ pub const Router = struct {
 
     pub fn get_bundle_from_host(
         self: *const Router,
+        allocator: std.mem.Allocator,
         path: []const u8,
         captures: []Capture,
         queries: *AnyCaseStringMap,
     ) !FoundBundle {
         queries.clearRetainingCapacity();
 
-        return try self.routes.get_bundle(path, captures, queries) orelse {
+        return try self.routes.get_bundle(allocator, path, captures, queries) orelse {
             const not_found_bundle: Bundle = .{
                 .route = Route.init("").all({}, self.configuration.not_found),
                 .middlewares = &.{},
             };
-            return .{ .bundle = not_found_bundle, .captures = captures[0..0], .queries = queries };
+            return .{ .bundle = not_found_bundle, .captures = captures[0..0], .queries = queries, .duped = &.{} };
         };
     }
 };

--- a/src/http/server.zig
+++ b/src/http/server.zig
@@ -367,6 +367,7 @@ pub const Server = struct {
                     &provision.queries,
                 );
                 defer rt.allocator.free(found.duped);
+                defer for (found.duped) |dupe| rt.allocator.free(dupe);
 
                 const h_with_data: HandlerWithData = found.bundle.route.get_handler(
                     provision.request.method.?,

--- a/src/http/server.zig
+++ b/src/http/server.zig
@@ -513,7 +513,10 @@ pub const Server = struct {
         // initialize first batch of provisions :)
         for (provision_pool.items) |*provision| {
             provision.initalized = true;
-            provision.zc_recv_buffer = ZeroCopy(u8).init(rt.allocator, self.config.socket_buffer_bytes) catch {
+            provision.zc_recv_buffer = ZeroCopy(u8).init(
+                rt.allocator,
+                self.config.socket_buffer_bytes,
+            ) catch {
                 @panic("attempting to allocate more memory than available. (ZeroCopy)");
             };
             provision.header_buffer = std.ArrayList(u8).init(rt.allocator);
@@ -527,7 +530,16 @@ pub const Server = struct {
         }
 
         try rt.spawn(
-            .{ rt, self.config, router, socket, self.tls_ctx, provision_pool, connection_count, accept_queued },
+            .{
+                rt,
+                self.config,
+                router,
+                socket,
+                self.tls_ctx,
+                provision_pool,
+                connection_count,
+                accept_queued,
+            },
             main_frame,
             self.config.stack_size,
         );


### PR DESCRIPTION
Adds support for URL Encoded Forms. This is supporting BOTH the params in the URL along with the params in the body.

It provides a `Form` method that will automatically parse your struct out based on fields from the URL Encoded form.

Closes #28.