### PR TITLE
Apply Middleware per Handler

### DIFF
--- a/docs/https.md
+++ b/docs/https.md
@@ -64,7 +64,6 @@ pub fn main() !void {
         ).layer(),
     }, .{});
     defer router.deinit(allocator);
-    router.print_route_tree();
 
     // create socket for tardy
     var socket = try Socket.init(.{ .tcp = .{ .host = host, .port = port } });

--- a/examples/fs/main.zig
+++ b/examples/fs/main.zig
@@ -57,7 +57,6 @@ pub fn main() !void {
         FsDir.serve("/", static_dir),
     }, .{});
     defer router.deinit(allocator);
-    router.print_route_tree();
 
     const EntryParams = struct {
         router: *const Router,

--- a/examples/middleware/main.zig
+++ b/examples/middleware/main.zig
@@ -69,7 +69,6 @@ pub fn main() !void {
         Route.init("/fail").get(num, root_handler).layer(),
     }, .{});
     defer router.deinit(allocator);
-    router.print_route_tree();
 
     const EntryParams = struct {
         router: *const Router,

--- a/examples/middleware/main.zig
+++ b/examples/middleware/main.zig
@@ -66,6 +66,7 @@ pub fn main() !void {
         Middleware.init({}, passing_middleware).layer(),
         Route.init("/").get(num, root_handler).layer(),
         Middleware.init({}, failing_middleware).layer(),
+        Route.init("/").post(num, root_handler).layer(),
         Route.init("/fail").get(num, root_handler).layer(),
     }, .{});
     defer router.deinit(allocator);

--- a/examples/tls/main.zig
+++ b/examples/tls/main.zig
@@ -59,7 +59,6 @@ pub fn main() !void {
         ).layer(),
     }, .{});
     defer router.deinit(allocator);
-    router.print_route_tree();
 
     // create socket for tardy
     var socket = try Socket.init(.{ .tcp = .{ .host = host, .port = port } });

--- a/examples/unix/main.zig
+++ b/examples/unix/main.zig
@@ -39,7 +39,6 @@ pub fn main() !void {
         Route.init("/").get({}, root_handler).layer(),
     }, .{});
     defer router.deinit(allocator);
-    router.print_route_tree();
 
     const EntryParams = struct {
         router: *const Router,

--- a/src/http/method.zig
+++ b/src/http/method.zig
@@ -1,16 +1,16 @@
 const std = @import("std");
 const log = std.log.scoped(.@"zzz/http/method");
 
-pub const Method = enum {
-    GET,
-    HEAD,
-    POST,
-    PUT,
-    DELETE,
-    CONNECT,
-    OPTIONS,
-    TRACE,
-    PATCH,
+pub const Method = enum(u8) {
+    GET = 0,
+    HEAD = 1,
+    POST = 2,
+    PUT = 3,
+    DELETE = 4,
+    CONNECT = 5,
+    OPTIONS = 6,
+    TRACE = 7,
+    PATCH = 8,
 
     fn encode(method: []const u8) u64 {
         var buffer = [1]u8{0} ** @sizeOf(u64);

--- a/src/http/router.zig
+++ b/src/http/router.zig
@@ -7,7 +7,6 @@ const Route = @import("router/route.zig").Route;
 const TypedHandlerFn = @import("router/route.zig").TypedHandlerFn;
 
 const Bundle = @import("router/routing_trie.zig").Bundle;
-const FoundBundle = @import("router/routing_trie.zig").FoundBundle;
 
 const Capture = @import("router/routing_trie.zig").Capture;
 const Request = @import("request.zig").Request;
@@ -59,25 +58,20 @@ pub const Router = struct {
         self.routes.deinit(allocator);
     }
 
-    pub fn print_route_tree(self: *const Router) void {
-        self.routes.print();
-    }
-
     pub fn get_bundle_from_host(
         self: *const Router,
         allocator: std.mem.Allocator,
         path: []const u8,
         captures: []Capture,
         queries: *AnyCaseStringMap,
-    ) !FoundBundle {
+    ) !Bundle {
         queries.clearRetainingCapacity();
 
-        return try self.routes.get_bundle(allocator, path, captures, queries) orelse {
-            const not_found_bundle: Bundle = .{
-                .route = Route.init("").all({}, self.configuration.not_found),
-                .middlewares = &.{},
-            };
-            return .{ .bundle = not_found_bundle, .captures = captures[0..0], .queries = queries, .duped = &.{} };
+        return try self.routes.get_bundle(allocator, path, captures, queries) orelse Bundle{
+            .route = Route.init("").all({}, self.configuration.not_found),
+            .captures = captures[0..],
+            .queries = queries,
+            .duped = &.{},
         };
     }
 };

--- a/src/http/router/route.zig
+++ b/src/http/router/route.zig
@@ -37,20 +37,6 @@ pub const Route = struct {
     /// Route Handlers.
     handlers: [9]?HandlerWithData = .{null} ** 9,
 
-    fn method_to_index(method: Method) u32 {
-        return switch (method) {
-            .GET => 0,
-            .HEAD => 1,
-            .POST => 2,
-            .PUT => 3,
-            .DELETE => 4,
-            .CONNECT => 5,
-            .OPTIONS => 6,
-            .TRACE => 7,
-            .PATCH => 8,
-        };
-    }
-
     /// Initialize a route for the given path.
     pub fn init(path: []const u8) Route {
         return Route{ .path = path };
@@ -91,7 +77,7 @@ pub const Route = struct {
     /// Get a defined request handler for the provided method.
     /// Return NULL if no handler is defined for this method.
     pub fn get_handler(self: Route, method: Method) ?HandlerWithData {
-        return self.handlers[method_to_index(method)];
+        return self.handlers[@intFromEnum(method)];
     }
 
     pub fn layer(self: Route) Layer {
@@ -107,7 +93,7 @@ pub const Route = struct {
     ) Route {
         const wrapped = wrap(usize, data);
         var new_handlers = self.handlers;
-        new_handlers[comptime method_to_index(method)] = .{
+        new_handlers[comptime @intFromEnum(method)] = .{
             .handler = @ptrCast(handler_fn),
             .middlewares = &.{},
             .data = wrapped,

--- a/src/http/router/route.zig
+++ b/src/http/router/route.zig
@@ -16,6 +16,8 @@ const FsDir = @import("fs_dir.zig").FsDir;
 const Context = @import("../context.zig").Context;
 const Layer = @import("middleware.zig").Layer;
 
+const MiddlewareWithData = @import("middleware.zig").MiddlewareWithData;
+
 pub const HandlerFn = *const fn (*const Context, usize) anyerror!Respond;
 pub fn TypedHandlerFn(comptime T: type) type {
     return *const fn (*const Context, T) anyerror!Respond;
@@ -23,18 +25,17 @@ pub fn TypedHandlerFn(comptime T: type) type {
 
 pub const HandlerWithData = struct {
     handler: HandlerFn,
+    middlewares: []const MiddlewareWithData,
     data: usize,
 };
 
 /// Structure of a server route definition.
 pub const Route = struct {
-    const Self = @This();
-
     /// Defined route path.
     path: []const u8,
 
-    /// Route handlers.
-    handlers: [9]?HandlerWithData = [_]?HandlerWithData{null} ** 9,
+    /// Route Handlers.
+    handlers: [9]?HandlerWithData = .{null} ** 9,
 
     fn method_to_index(method: Method) u32 {
         return switch (method) {
@@ -51,13 +52,13 @@ pub const Route = struct {
     }
 
     /// Initialize a route for the given path.
-    pub fn init(path: []const u8) Self {
-        return Self{ .path = path };
+    pub fn init(path: []const u8) Route {
+        return Route{ .path = path };
     }
 
     /// Returns a comma delinated list of allowed Methods for this route. This
     /// is meant to be used as the value for the 'Allow' header in the Response.
-    pub fn get_allowed(self: Self, allocator: std.mem.Allocator) ![]const u8 {
+    pub fn get_allowed(self: Route, allocator: std.mem.Allocator) ![]const u8 {
         // This gets allocated within the context of the connection's arena.
         const allowed_size = comptime blk: {
             var size = 0;
@@ -89,82 +90,84 @@ pub const Route = struct {
 
     /// Get a defined request handler for the provided method.
     /// Return NULL if no handler is defined for this method.
-    pub fn get_handler(self: Self, method: Method) ?HandlerWithData {
+    pub fn get_handler(self: Route, method: Method) ?HandlerWithData {
         return self.handlers[method_to_index(method)];
     }
 
-    pub fn layer(self: Self) Layer {
+    pub fn layer(self: Route) Layer {
         return .{ .route = self };
     }
 
     /// Set a handler function for the provided method.
     inline fn inner_route(
         comptime method: Method,
-        self: Self,
+        self: Route,
         data: anytype,
         handler_fn: TypedHandlerFn(@TypeOf(data)),
-    ) Self {
+    ) Route {
         const wrapped = wrap(usize, data);
         var new_handlers = self.handlers;
         new_handlers[comptime method_to_index(method)] = .{
             .handler = @ptrCast(handler_fn),
+            .middlewares = &.{},
             .data = wrapped,
         };
 
-        return Self{ .path = self.path, .handlers = new_handlers };
+        return Route{ .path = self.path, .handlers = new_handlers };
     }
 
     /// Set a handler function for all methods.
-    pub fn all(self: Self, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Self {
+    pub fn all(self: Route, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Route {
         const wrapped = wrap(usize, data);
         var new_handlers = self.handlers;
 
         for (&new_handlers) |*new_handler| {
             new_handler.* = .{
                 .handler = @ptrCast(handler_fn),
+                .middlewares = &.{},
                 .data = wrapped,
             };
         }
 
-        return Self{
+        return Route{
             .path = self.path,
             .handlers = new_handlers,
         };
     }
 
-    pub fn get(self: Self, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Self {
+    pub fn get(self: Route, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Route {
         return inner_route(.GET, self, data, handler_fn);
     }
 
-    pub fn head(self: Self, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Self {
+    pub fn head(self: Route, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Route {
         return inner_route(.HEAD, self, handler_fn);
     }
 
-    pub fn post(self: Self, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Self {
+    pub fn post(self: Route, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Route {
         return inner_route(.POST, self, data, handler_fn);
     }
 
-    pub fn put(self: Self, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Self {
+    pub fn put(self: Route, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Route {
         return inner_route(.PUT, self, data, handler_fn);
     }
 
-    pub fn delete(self: Self, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Self {
+    pub fn delete(self: Route, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Route {
         return inner_route(.DELETE, self, data, handler_fn);
     }
 
-    pub fn connect(self: Self, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Self {
+    pub fn connect(self: Route, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Route {
         return inner_route(.CONNECT, self, data, handler_fn);
     }
 
-    pub fn options(self: Self, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Self {
+    pub fn options(self: Route, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Route {
         return inner_route(.OPTIONS, self, data, handler_fn);
     }
 
-    pub fn trace(self: Self, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Self {
+    pub fn trace(self: Route, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Route {
         return inner_route(.TRACE, self, data, handler_fn);
     }
 
-    pub fn patch(self: Self, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Self {
+    pub fn patch(self: Route, data: anytype, handler_fn: TypedHandlerFn(@TypeOf(data))) Route {
         return inner_route(.PATCH, self, data, handler_fn);
     }
 
@@ -177,10 +180,10 @@ pub const Route = struct {
 
     /// Define a GET handler to serve an embedded file.
     pub fn embed_file(
-        self: *const Self,
+        self: *const Route,
         comptime opts: ServeEmbeddedOptions,
         comptime bytes: []const u8,
-    ) Self {
+    ) Route {
         return self.get({}, struct {
             fn handler_fn(ctx: *const Context, _: void) !Respond {
                 var header_list = try std.ArrayListUnmanaged([2][]const u8).initCapacity(ctx.allocator, 3);

--- a/src/http/router/routing_trie.zig
+++ b/src/http/router/routing_trie.zig
@@ -394,14 +394,14 @@ test "Routing with Paths" {
     {
         const captured = (try s.get_bundle(testing.allocator, "/item/name/HELLO", captures[0..], &q)).?;
 
-        try testing.expectEqual(Route.init("/item/name/%s"), captured.bundle.route);
+        try testing.expectEqual(Route.init("/item/name/%s"), captured.route);
         try testing.expectEqualStrings("HELLO", captured.captures[0].string);
     }
 
     {
         const captured = (try s.get_bundle(testing.allocator, "/item/2112.22121/price_float", captures[0..], &q)).?;
 
-        try testing.expectEqual(Route.init("/item/%f/price_float"), captured.bundle.route);
+        try testing.expectEqual(Route.init("/item/%f/price_float"), captured.route);
         try testing.expectEqual(2112.22121, captured.captures[0].float);
     }
 }
@@ -424,7 +424,7 @@ test "Routing with Remaining" {
 
     {
         const captured = (try s.get_bundle(testing.allocator, "/item/name/HELLO", captures[0..], &q)).?;
-        try testing.expectEqual(Route.init("/item/name/%r"), captured.bundle.route);
+        try testing.expectEqual(Route.init("/item/name/%r"), captured.route);
         try testing.expectEqualStrings("HELLO", captured.captures[0].remaining);
     }
     {
@@ -434,7 +434,7 @@ test "Routing with Remaining" {
             captures[0..],
             &q,
         )).?;
-        try testing.expectEqual(Route.init("/item/name/%r"), captured.bundle.route);
+        try testing.expectEqual(Route.init("/item/name/%r"), captured.route);
         try testing.expectEqualStrings("THIS/IS/A/FILE/SYSTEM/PATH.html", captured.captures[0].remaining);
     }
 
@@ -445,7 +445,7 @@ test "Routing with Remaining" {
             captures[0..],
             &q,
         )).?;
-        try testing.expectEqual(Route.init("/item/%f/price_float"), captured.bundle.route);
+        try testing.expectEqual(Route.init("/item/%f/price_float"), captured.route);
         try testing.expectEqual(2112.22121, captured.captures[0].float);
     }
 
@@ -456,7 +456,7 @@ test "Routing with Remaining" {
             captures[0..],
             &q,
         )).?;
-        try testing.expectEqual(Route.init("/item/%i/price/%f"), captured.bundle.route);
+        try testing.expectEqual(Route.init("/item/%i/price/%f"), captured.route);
         try testing.expectEqual(100, captured.captures[0].signed);
         try testing.expectEqual(283.21, captured.captures[1].float);
     }
@@ -493,7 +493,7 @@ test "Routing with Queries" {
         )).?;
         defer testing.allocator.free(captured.duped);
         defer for (captured.duped) |dupe| testing.allocator.free(dupe);
-        try testing.expectEqual(Route.init("/item/name/%r"), captured.bundle.route);
+        try testing.expectEqual(Route.init("/item/name/%r"), captured.route);
         try testing.expectEqualStrings("HELLO", captured.captures[0].remaining);
         try testing.expectEqual(2, q.count());
         try testing.expectEqualStrings("muki", q.get("name").?);
@@ -511,7 +511,7 @@ test "Routing with Queries" {
         )).?;
         defer testing.allocator.free(captured.duped);
         defer for (captured.duped) |dupe| testing.allocator.free(dupe);
-        try testing.expectEqual(Route.init("/item/%f/price_float"), captured.bundle.route);
+        try testing.expectEqual(Route.init("/item/%f/price_float"), captured.route);
         try testing.expectEqual(2112.22121, captured.captures[0].float);
         try testing.expectEqual(0, q.count());
     }
@@ -527,7 +527,7 @@ test "Routing with Queries" {
         )).?;
         defer testing.allocator.free(captured.duped);
         defer for (captured.duped) |dupe| testing.allocator.free(dupe);
-        try testing.expectEqual(Route.init("/item/%i/price/%f"), captured.bundle.route);
+        try testing.expectEqual(Route.init("/item/%i/price/%f"), captured.route);
         try testing.expectEqual(100, captured.captures[0].signed);
         try testing.expectEqual(283.21, captured.captures[1].float);
         try testing.expectEqual(0, q.count());

--- a/src/http/router/routing_trie.zig
+++ b/src/http/router/routing_trie.zig
@@ -127,18 +127,16 @@ pub const RoutingTrie = struct {
 
     /// Structure of a node of the trie.
     pub const Node = struct {
-        pub const ChildrenMap = TokenHashMap(Node);
-
         token: Token,
         route: ?Route = null,
-        children: ChildrenMap,
+        children: TokenHashMap(Node),
 
         /// Initialize a new empty node.
         pub fn init(allocator: std.mem.Allocator, token: Token, route: ?Route) Node {
             return .{
                 .token = token,
                 .route = route,
-                .children = ChildrenMap.init(allocator),
+                .children = TokenHashMap(Node).init(allocator),
             };
         }
 
@@ -185,9 +183,11 @@ pub const RoutingTrie = struct {
                     };
 
                     for (route.handlers, 0..) |handler, i| if (handler) |h| {
-                        const slot_ptr: *HandlerWithData = @ptrCast(&r.handlers[i]);
-                        slot_ptr.* = h;
-                        slot_ptr.middlewares = self.middlewares.items;
+                        r.handlers[i] = HandlerWithData{
+                            .handler = h.handler,
+                            .middlewares = self.middlewares.items,
+                            .data = h.data,
+                        };
                     };
                 },
                 .middleware => |mw| try self.middlewares.append(allocator, mw),

--- a/src/http/router/routing_trie.zig
+++ b/src/http/router/routing_trie.zig
@@ -8,15 +8,11 @@ const Route = @import("route.zig").Route;
 const Respond = @import("../response.zig").Respond;
 const Context = @import("../lib.zig").Context;
 
+const HandlerWithData = @import("route.zig").HandlerWithData;
 const MiddlewareWithData = @import("middleware.zig").MiddlewareWithData;
 const AnyCaseStringMap = @import("../../core/any_case_string_map.zig").AnyCaseStringMap;
 
 const decode_alloc = @import("../form.zig").decode_alloc;
-
-pub const Bundle = struct {
-    route: Route,
-    middlewares: []const MiddlewareWithData,
-};
 
 fn TokenHashMap(comptime V: type) type {
     return std.HashMap(Token, V, struct {
@@ -118,8 +114,8 @@ pub const Capture = union(TokenMatch) {
 };
 
 /// Structure of a matched route.
-pub const FoundBundle = struct {
-    bundle: Bundle,
+pub const Bundle = struct {
+    route: Route,
     captures: []Capture,
     queries: *AnyCaseStringMap,
     duped: []const []const u8,
@@ -134,14 +130,14 @@ pub const RoutingTrie = struct {
         pub const ChildrenMap = TokenHashMap(Node);
 
         token: Token,
-        bundle: ?Bundle = null,
+        route: ?Route = null,
         children: ChildrenMap,
 
         /// Initialize a new empty node.
-        pub fn init(allocator: std.mem.Allocator, token: Token, bundle: ?Bundle) Node {
+        pub fn init(allocator: std.mem.Allocator, token: Token, route: ?Route) Node {
             return .{
                 .token = token,
-                .bundle = bundle,
+                .route = route,
                 .children = ChildrenMap.init(allocator),
             };
         }
@@ -183,9 +179,15 @@ pub const RoutingTrie = struct {
                         }
                     }
 
-                    current.bundle = .{
-                        .route = route,
-                        .middlewares = self.middlewares.items,
+                    const r: *Route = if (current.route) |*inner| inner else blk: {
+                        current.route = route;
+                        break :blk &current.route.?;
+                    };
+
+                    for (route.handlers, 0..) |handler, i| if (handler) |h| {
+                        const slot_ptr: *HandlerWithData = @ptrCast(&r.handlers[i]);
+                        slot_ptr.* = h;
+                        slot_ptr.middlewares = self.middlewares.items;
                     };
                 },
                 .middleware => |mw| try self.middlewares.append(allocator, mw),
@@ -200,45 +202,13 @@ pub const RoutingTrie = struct {
         self.middlewares.deinit(allocator);
     }
 
-    fn print_node(root: *const Node, depth: usize) void {
-        var i: usize = 0;
-        while (i < depth) : (i += 1) {
-            std.debug.print(" │  ", .{});
-        }
-
-        std.debug.print(" ├ ", .{});
-
-        switch (root.token) {
-            .fragment => |inner| std.debug.print("Token: \"{s}\"", .{inner}),
-            .match => |match| std.debug.print("Token: match {s}", .{@tagName(match)}),
-        }
-
-        if (root.bundle) |bundle| {
-            std.debug.print(" [x] ({d})", .{bundle.middlewares.len});
-        } else {
-            std.debug.print(" [ ]", .{});
-        }
-        std.debug.print("\n", .{});
-
-        var iter = root.children.valueIterator();
-
-        while (iter.next()) |node| {
-            print_node(node, depth + 1);
-        }
-    }
-
-    pub fn print(self: *const Self) void {
-        std.debug.print("Root: \n", .{});
-        print_node(&self.root, 0);
-    }
-
     pub fn get_bundle(
         self: Self,
         allocator: std.mem.Allocator,
         path: []const u8,
         captures: []Capture,
         queries: *AnyCaseStringMap,
-    ) !?FoundBundle {
+    ) !?Bundle {
         var capture_idx: usize = 0;
         const query_pos = std.mem.indexOfScalar(u8, path, '?');
         var iter = std.mem.tokenizeScalar(u8, path[0..(query_pos orelse path.len)], '/');
@@ -321,8 +291,8 @@ pub const RoutingTrie = struct {
             }
         }
 
-        return .{
-            .bundle = current.bundle orelse return null,
+        return Bundle{
+            .route = current.route orelse return null,
             .captures = captures[0..capture_idx],
             .queries = queries,
             .duped = try duped.toOwnedSlice(allocator),

--- a/src/http/server.zig
+++ b/src/http/server.zig
@@ -369,7 +369,7 @@ pub const Server = struct {
                 defer rt.allocator.free(found.duped);
                 defer for (found.duped) |dupe| rt.allocator.free(dupe);
 
-                const h_with_data: HandlerWithData = found.bundle.route.get_handler(
+                const h_with_data: HandlerWithData = found.route.get_handler(
                     provision.request.method.?,
                 ) orelse {
                     try provision.response.apply(.{
@@ -395,7 +395,7 @@ pub const Server = struct {
 
                 var next: Next = .{
                     .context = &context,
-                    .middlewares = found.bundle.middlewares,
+                    .middlewares = h_with_data.middlewares,
                     .handler = h_with_data,
                 };
 


### PR DESCRIPTION
This changes the general behavior of middleware, moving it from a Route level to the Handler level. This allows for different methods within the same Route to have different middleware applied to it.

Closes #26 